### PR TITLE
feat(openai): Enhance OpenAIClient Configuration and Fix Kwargs Handling

### DIFF
--- a/datapizza-ai-clients/datapizza-ai-clients-openai/datapizza/clients/openai/openai_client.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-openai/datapizza/clients/openai/openai_client.py
@@ -47,6 +47,15 @@ class OpenAIClient(Client):
         temperature: float | None = None,
         cache: Cache | None = None,
         base_url: str | httpx.URL | None = None,
+        organization: str | None = None,
+        project: str | None = None,
+        webhook_secret: str | None = None,
+        websocket_base_url: str | httpx.URL | None = None,
+        timeout: float | httpx.Timeout | None = None,
+        max_retries: int = 2,
+        default_headers: dict[str, str] | None = None,
+        default_query: dict[str, object] | None = None,
+        http_client: httpx.Client | None = None,
     ):
         """
         Args:
@@ -56,6 +65,15 @@ class OpenAIClient(Client):
             temperature: The temperature to use for the OpenAI API.
             cache: The cache to use for the OpenAI API.
             base_url: The base URL for the OpenAI API.
+            organization: The organization ID for the OpenAI API.
+            project: The project ID for the OpenAI API.
+            webhook_secret: The webhook secret for the OpenAI API.
+            websocket_base_url: The websocket base URL for the OpenAI API.
+            timeout: The timeout for the OpenAI API.
+            max_retries: The max retries for the OpenAI API.
+            default_headers: The default headers for the OpenAI API.
+            default_query: The default query for the OpenAI API.
+            http_client: The http_client for the OpenAI API.
         """
 
         if temperature and not 0 <= temperature <= 2:
@@ -68,18 +86,51 @@ class OpenAIClient(Client):
             cache=cache,
         )
 
-        self.base_url = base_url
         self.api_key = api_key
+        self.base_url = base_url
+        self.organization = organization
+        self.project = project
+        self.webhook_secret = webhook_secret
+        self.websocket_base_url = websocket_base_url
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.default_headers = default_headers
+        self.default_query = default_query
+        self.http_client = http_client
+
         self.memory_adapter = OpenAIMemoryAdapter()
         self._set_client()
 
     def _set_client(self):
         if not self.client:
-            self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+            self.client = OpenAI(
+                api_key=self.api_key,
+                base_url=self.base_url,
+                organization=self.organization,
+                project=self.project,
+                webhook_secret=self.webhook_secret,
+                websocket_base_url=self.websocket_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                default_headers=self.default_headers,
+                default_query=self.default_query,
+                http_client=self.http_client,
+            )
 
     def _set_a_client(self):
         if not self.a_client:
-            self.a_client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
+            self.a_client = AsyncOpenAI(
+                api_key=self.api_key,
+                base_url=self.base_url,
+                organization=self.organization,
+                project=self.project,
+                webhook_secret=self.webhook_secret,
+                websocket_base_url=self.websocket_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                default_headers=self.default_headers,
+                default_query=self.default_query,
+            )
 
     def _response_to_client_response(
         self, response, tool_map: dict[str, Tool] | None
@@ -192,11 +243,11 @@ class OpenAIClient(Client):
         tool_map = {tool.name: tool for tool in tools}
 
         kwargs = {
+            **kwargs,
             "model": self.model_name,
             "input": messages,
             "stream": False,
             "max_output_tokens": max_tokens,
-            **kwargs,
         }
         if temperature:
             kwargs["temperature"] = temperature
@@ -228,11 +279,11 @@ class OpenAIClient(Client):
         tool_map = {tool.name: tool for tool in tools}
 
         kwargs = {
+            **kwargs,
             "model": self.model_name,
             "input": messages,
             "stream": False,
             "max_output_tokens": max_tokens,
-            **kwargs,
         }
         if temperature:
             kwargs["temperature"] = temperature
@@ -263,12 +314,12 @@ class OpenAIClient(Client):
         tool_map = {tool.name: tool for tool in tools}
 
         kwargs = {
+            **kwargs,
             "model": self.model_name,
             "input": messages,
             "stream": True,
             "max_output_tokens": max_tokens,
             # "stream_options": {"include_usage": True},
-            **kwargs,
         }
         if temperature:
             kwargs["temperature"] = temperature
@@ -309,12 +360,12 @@ class OpenAIClient(Client):
 
         tool_map = {tool.name: tool for tool in tools}
         kwargs = {
+            **kwargs,
             "model": self.model_name,
             "input": messages,
             "stream": True,
             "max_output_tokens": max_tokens,
             # "stream_options": {"include_usage": True},
-            **kwargs,
         }
         if temperature:
             kwargs["temperature"] = temperature

--- a/datapizza-ai-clients/datapizza-ai-clients-openai/tests/test_base_client.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-openai/tests/test_base_client.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch, MagicMock
+import httpx
 from datapizza.clients.openai import (
     OpenAIClient,
 )
+from datapizza.core.clients import ClientResponse
 
 
 def test_client_init():
@@ -9,3 +12,88 @@ def test_client_init():
         api_key="test_api_key",
     )
     assert client is not None
+
+@patch("datapizza.clients.openai.openai_client.OpenAI")
+def test_client_init_with_extra_args(mock_openai):
+    """Tests that extra arguments are passed to the OpenAI client."""
+    OpenAIClient(
+        api_key="test_api_key",
+        organization="test-org",
+        project="test-project",
+        timeout=30.0,
+        max_retries=3,
+    )
+    mock_openai.assert_called_once_with(
+        api_key="test_api_key",
+        base_url=None,
+        organization="test-org",
+        project="test-project",
+        webhook_secret=None,
+        websocket_base_url=None,
+        timeout=30.0,
+        max_retries=3,
+        default_headers=None,
+        default_query=None,
+        http_client=None,
+    )
+
+@patch("datapizza.clients.openai.openai_client.OpenAI")
+def test_client_init_with_http_client(mock_openai):
+    """Tests that a custom http_client is passed to the OpenAI client."""
+    custom_http_client = httpx.Client()
+    OpenAIClient(
+        api_key="test_api_key",
+        http_client=custom_http_client,
+    )
+    mock_openai.assert_called_once_with(
+        api_key="test_api_key",
+        base_url=None,
+        organization=None,
+        project=None,
+        webhook_secret=None,
+        websocket_base_url=None,
+        timeout=None,
+        max_retries=2,
+        default_headers=None,
+        default_query=None,
+        http_client=custom_http_client,
+    )
+
+@patch("datapizza.clients.openai.openai_client.OpenAI")
+def test_invoke_kwargs_override(mock_openai_class):
+    """
+    Tests that kwargs like 'stream' are not overridden by user input
+    in non-streaming methods, but other kwargs are passed through.
+    """
+    mock_openai_instance = mock_openai_class.return_value
+    mock_openai_instance.responses.create.return_value = MagicMock()
+
+    client = OpenAIClient(api_key="test")
+    client._response_to_client_response = MagicMock(return_value=ClientResponse(content=[]))
+
+    client.invoke("hello", stream=True, top_p=0.5)
+
+    mock_openai_instance.responses.create.assert_called_once()
+    called_kwargs = mock_openai_instance.responses.create.call_args.kwargs
+    
+    assert called_kwargs.get("top_p") == 0.5
+    assert called_kwargs.get("stream") is False
+
+@patch("datapizza.clients.openai.openai_client.OpenAI")
+def test_stream_invoke_kwargs_override(mock_openai_class):
+    """
+    Tests that kwargs like 'stream' are not overridden by user input
+    in streaming methods.
+    """
+    mock_openai_instance = mock_openai_class.return_value
+    mock_openai_instance.responses.create.return_value = []
+
+    client = OpenAIClient(api_key="test")
+
+    list(client.stream_invoke("hello", stream=False, top_p=0.5))
+
+    mock_openai_instance.responses.create.assert_called_once()
+    called_kwargs = mock_openai_instance.responses.create.call_args.kwargs
+    
+    assert called_kwargs.get("top_p") == 0.5
+    assert called_kwargs.get("stream") is True


### PR DESCRIPTION
This PR enhances the `OpenAIClient` and improves its robustness.

## Changes

### 1. Enhanced `OpenAIClient` Configuration

The `OpenAIClient` constructor has been updated to accept a wider range of arguments from the official `openai-python` library, including:
- `organization`
- `project`
- `webhook_secret`
- `websocket_base_url`
- `timeout`
- `max_retries`
- `default_headers`
- `default_query`
- `http_client`

This allows for more advanced and flexible configuration of the client directly upon initialization.

### 2. Bug Fix: `kwargs` Overriding in `invoke` Methods

A bug was identified and fixed where user-provided `kwargs` in `invoke` and `stream_invoke` methods could override critical internal parameters (like `stream`). The logic has been corrected to ensure that the method's internal parameters take precedence, preventing unexpected behavior while still allowing other `kwargs` to be passed through.

### 3. Added Tests

Comprehensive tests have been added to cover the new functionality:
- Verifying that the new constructor arguments are correctly passed to the underlying `openai.OpenAI` client.
- Ensuring that the `kwargs` override bug is fixed by explicitly testing that critical parameters cannot be overridden by user input in both streaming and non-streaming methods.

All tests are passing, ensuring the stability of these changes.

#35 #34 