### PR TITLE
Add support for all supported extensions to Docling module 

### DIFF
--- a/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/tests/conftest.py
+++ b/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+from datapizza.modules.parsers.docling.docling_parser import DoclingParser
+
+
+@pytest.fixture
+def mock_docling_parser(monkeypatch, tmp_path):
+    """
+    Fixture to create a DoclingParser instance with mocked converter behavior.
+    """
+    parser = DoclingParser(json_output_dir=str(tmp_path))
+
+    # Mock converter and convert() result
+    class MockResult:
+        def __init__(self):
+            self.document = self
+
+        def export_to_dict(self):
+            # Minimal fake Docling JSON
+            return {
+                "schema_name": "docling_test",
+                "version": "1.0",
+                "name": "mock_doc",
+                "origin": "unit_test",
+                "body": {"children": []},
+            }
+
+    class MockConverter:
+        def convert(self, file_path):
+            return MockResult()
+
+    monkeypatch.setattr(parser, "_get_converter", lambda: MockConverter())
+    return parser

--- a/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/tests/test_docling_parser.py
+++ b/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/tests/test_docling_parser.py
@@ -1,0 +1,56 @@
+import warnings
+
+import pytest
+from datapizza.type import Node, NodeType
+
+from datapizza.modules.parsers.docling.docling_parser import DoclingParser
+
+
+def test_parse_with_file_path(mock_docling_parser, tmp_path):
+    """Test that parse() works with the new 'file_path' parameter."""
+    dummy_file = tmp_path / "dummy.pdf"
+    dummy_file.write_text("fake-pdf-content")
+
+    node = mock_docling_parser.parse(file_path=str(dummy_file))
+    assert isinstance(node, Node)
+    assert node.node_type == NodeType.DOCUMENT
+    assert node.metadata["name"] == "mock_doc"
+    assert node.metadata["schema_name"] == "docling_test"
+
+
+def test_parse_with_pdf_path_deprecated(mock_docling_parser, tmp_path):
+    """Test that parse() still works with deprecated 'pdf_path' and issues a warning."""
+    dummy_file = tmp_path / "legacy.pdf"
+    dummy_file.write_text("fake-pdf")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        node = mock_docling_parser.parse(pdf_path=str(dummy_file))
+
+        assert isinstance(node, Node)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "pdf_path" in str(w[0].message)
+
+
+def test_parse_with_both_file_and_pdf_path(mock_docling_parser, tmp_path):
+    """Ensure file_path takes precedence if both are given."""
+    dummy_file1 = tmp_path / "primary.pdf"
+    dummy_file1.write_text("pdf1")
+    dummy_file2 = tmp_path / "secondary.pdf"
+    dummy_file2.write_text("pdf2")
+
+    with warnings.catch_warnings(record=True) as w:
+        node = mock_docling_parser.parse(
+            file_path=str(dummy_file1), pdf_path=str(dummy_file2)
+        )
+
+        # Expect a warning but use file_path
+        assert len(w) == 1
+        assert node.metadata["name"] == "mock_doc"
+
+
+def test_parse_missing_file_path_raises():
+    parser = DoclingParser()
+    with pytest.raises(ValueError, match="Missing required argument: file_path"):
+        parser.parse()

--- a/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/utils.py
+++ b/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/utils.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-
 def extract_media_from_docling_bbox(
     bbox: dict,
     file_path: str,
@@ -89,7 +86,3 @@ def extract_media_from_docling_bbox(
         buf = io.BytesIO()
         crop.save(buf, format="PNG")
         return base64.b64encode(buf.getvalue()).decode("utf-8")
-
-
-def is_pdf_file(file_path: str) -> bool:
-    return Path(file_path).suffix.lower() == ".pdf"

--- a/datapizza-ai-modules/parsers/docling/mypy.ini
+++ b/datapizza-ai-modules/parsers/docling/mypy.ini
@@ -1,0 +1,11 @@
+[mypy-fitz.*]
+ignore_missing_imports = True
+
+[mypy-docling.*]
+ignore_missing_imports = True
+
+[mypy-datapizza.*]
+ignore_missing_imports = True
+
+[mypy]
+explicit_package_bases = True


### PR DESCRIPTION
This PR adds support for Markdown (.md) files in the Datapizza Docling module.

Related Issue: #21 