### PR TITLE
feat: support flexible OCR configuration for Docling parser

### DIFF
--- a/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/__init__.py
+++ b/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/__init__.py
@@ -1,3 +1,4 @@
 from .docling_parser import DoclingParser
+from .ocr_options import OCREngine, OCROptions
 
-__all__ = ["DoclingParser"]
+__all__ = ["DoclingParser", "OCREngine", "OCROptions"]

--- a/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/ocr_options.py
+++ b/datapizza-ai-modules/parsers/docling/datapizza/modules/parsers/docling/ocr_options.py
@@ -1,0 +1,101 @@
+"""
+OCR (Optical Character Recognition) configuration for Docling parser.
+
+This module provides flexible OCR engine management, allowing users to:
+- Select between different OCR engines (EasyOCR, Tesseract)
+- Disable OCR entirely
+- Configure engine-specific options
+
+Backward compatibility: Default is EasyOCR if no options are provided.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class OCREngine(str, Enum):
+    """
+    Supported OCR engines for document processing.
+
+    Attributes:
+        EASY_OCR: Use EasyOCR for text recognition
+        TESSERACT: Use Tesseract OCR engine
+        NONE: Disable OCR - use only PDF text extraction
+    """
+
+    EASY_OCR = "easy_ocr"
+    TESSERACT = "tesseract"
+    NONE = "none"
+
+    def __str__(self) -> str:
+        """Return human-readable name for the OCR engine."""
+        return {
+            self.EASY_OCR: "EasyOCR",
+            self.TESSERACT: "Tesseract",
+            self.NONE: "None",
+        }[self]
+
+
+@dataclass
+class OCROptions:
+    """
+    Configuration for OCR processing in Docling.
+
+    This dataclass allows fine-grained control over OCR behavior during
+    document parsing. Each OCR engine has its own set of parameters.
+
+    Attributes:
+        engine: The OCR engine to use (default: EASY_OCR for backward compatibility)
+        easy_ocr_force_full_page: Force full page OCR with EasyOCR (default: True)
+        tesseract_lang: Language codes for Tesseract as list (default: ["eng"])
+                       Examples: ["auto"], ["ita"], ["ita", "eng"], ["eng", "fra"]
+        tesseract_config: Additional Tesseract configuration string (default: "")
+    """
+
+    engine: OCREngine = field(default=OCREngine.EASY_OCR)
+    # EasyOCR specific options
+    easy_ocr_force_full_page: bool = field(default=True)
+    # Tesseract specific options
+    tesseract_lang: list[str] = field(default_factory=lambda: ["eng"])
+    tesseract_config: str = field(default="")
+
+    def to_docling_pipeline_options(self) -> dict[str, Any]:
+        """
+        Convert OCR options to Docling PdfPipelineOptions configuration.
+
+        This method translates our internal OCR configuration to the format
+        expected by Docling's DocumentConverter.
+
+        Returns:
+            Dictionary of pipeline kwargs suitable for PdfPipelineOptions.
+            Always includes "do_table_structure": True for consistency.
+        """
+        pipeline_kwargs: dict[str, Any] = {"do_table_structure": True}
+
+        if self.engine == OCREngine.NONE:
+            # No OCR - Docling will use built-in PDF text extraction only
+            return pipeline_kwargs
+
+        if self.engine == OCREngine.EASY_OCR:
+            # Import here to avoid dependency issues if EasyOCR not installed
+            from docling.datamodel.pipeline_options import EasyOcrOptions
+
+            ocr_options = EasyOcrOptions(
+                force_full_page_ocr=self.easy_ocr_force_full_page
+            )
+            pipeline_kwargs["ocr_options"] = ocr_options
+            return pipeline_kwargs
+
+        if self.engine == OCREngine.TESSERACT:
+            # Import here to support optional Tesseract dependency
+            from docling.datamodel.pipeline_options import TesseractOcrOptions
+
+            # tesseract_lang is already a list, pass it directly
+            ocr_options = TesseractOcrOptions(lang=self.tesseract_lang)
+            pipeline_kwargs["ocr_options"] = ocr_options
+            return pipeline_kwargs
+
+        # Fallback (should not reach here if Enum is exhaustive)
+        return pipeline_kwargs
+

--- a/docs/API Reference/Modules/Parsers/docling_parser.md
+++ b/docs/API Reference/Modules/Parsers/docling_parser.md
@@ -72,3 +72,126 @@ for section in document.children:
         elif child.node_type.name == "FIGURE":
             print(f"  Figure: {child.metadata.get('docling_label', 'Image')}")
 ```
+
+### Configured OCR Document Processing
+
+```python
+from datapizza.modules.parsers.docling import DoclingParser
+from datapizza.modules.parsers.docling.ocr_options import OCROptions, OCREngine
+
+# Configure parser with EasyOCR (default, backward compatible)
+parser = DoclingParser()
+document = parser.parse("document.pdf")
+
+# Configure parser with Tesseract OCR for Italian language
+ocr_config = OCROptions(
+    engine=OCREngine.TESSERACT,
+    tesseract_lang=["ita"],
+)
+parser = DoclingParser(ocr_options=ocr_config)
+document = parser.parse("italian_document.pdf")
+
+# Configure parser with Tesseract for multiple languages
+ocr_config = OCROptions(
+    engine=OCREngine.TESSERACT,
+    tesseract_lang=["eng", "fra"],  # English and French
+)
+parser = DoclingParser(ocr_options=ocr_config)
+document = parser.parse("multilingual_document.pdf")
+
+# Configure parser with Tesseract for Italian and English
+ocr_config = OCROptions(
+    engine=OCREngine.TESSERACT,
+    tesseract_lang=["ita", "eng"],
+)
+parser = DoclingParser(ocr_options=ocr_config)
+document = parser.parse("italian_english_document.pdf")
+
+# Configure parser with automatic language detection
+ocr_config = OCROptions(
+    engine=OCREngine.TESSERACT,
+    tesseract_lang=["auto"],
+)
+parser = DoclingParser(ocr_options=ocr_config)
+document = parser.parse("mixed_language_document.pdf")
+
+# Disable OCR completely (for documents without text that needs OCR)
+ocr_config = OCROptions(engine=OCREngine.NONE)
+parser = DoclingParser(ocr_options=ocr_config)
+document = parser.parse("native_text_document.pdf")
+
+# Enable custom EasyOCR configuration
+ocr_config = OCROptions(
+    engine=OCREngine.EASY_OCR,
+    easy_ocr_force_full_page=False,  # Process only text-light regions
+)
+parser = DoclingParser(ocr_options=ocr_config)
+document = parser.parse("document.pdf")
+
+# Parse with JSON output for debugging
+ocr_config = OCROptions(engine=OCREngine.TESSERACT, tesseract_lang=["ita", "eng"])
+parser = DoclingParser(
+    json_output_dir="./docling_debug",
+    ocr_options=ocr_config,
+)
+document = parser.parse("document.pdf")
+# Intermediate Docling JSON will be saved to ./docling_debug/document.json
+```
+
+### Tesseract Language Options
+
+When using Tesseract OCR, you can specify languages in the `tesseract_lang` parameter as a list:
+
+**Single Language:**
+```python
+ocr_config = OCROptions(
+    engine=OCREngine.TESSERACT,
+    tesseract_lang=["eng"],  # English
+)
+```
+
+**Multiple Languages:**
+```python
+ocr_config = OCROptions(
+    engine=OCREngine.TESSERACT,
+    tesseract_lang=["eng", "ita", "fra"],  # English, Italian, French
+)
+```
+
+**Automatic Language Detection:**
+```python
+ocr_config = OCROptions(
+    engine=OCREngine.TESSERACT,
+    tesseract_lang=["auto"],  # Auto-detect language
+)
+```
+
+**Common Language Codes:**
+- `"eng"` - English
+- `"ita"` - Italian
+- `"fra"` - French
+- `"deu"` - German
+- `"spa"` - Spanish
+- `"por"` - Portuguese
+- `"chi_sim"` - Simplified Chinese
+- `"chi_tra"` - Traditional Chinese
+- `"jpn"` - Japanese
+- `"auto"` - Automatic detection
+
+For a complete list of supported languages, refer to [Tesseract documentation](https://github.com/UB-Mannheim/tesseract/wiki).
+
+### Backward Compatibility
+
+The parser maintains backward compatibility with the deprecated `pdf_path` parameter:
+
+```python
+from datapizza.modules.parsers.docling import DoclingParser
+import warnings
+
+parser = DoclingParser()
+
+# This still works but issues a DeprecationWarning
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    document = parser.parse(pdf_path="document.pdf")  # Use file_path instead
+```


### PR DESCRIPTION
- Add OCROptions dataclass with support for multiple OCR engines (EasyOCR, Tesseract, None)
- Change tesseract_lang from string to list[str] for flexible multi-language support
  - Single language: ['ita']
  - Multiple languages: ['ita', 'eng', 'fra']
  - Auto-detection: ['auto']
- Implement to_docling_pipeline_options() method to convert options to Docling format
- Update DoclingParser to accept optional ocr_options parameter
- Export OCREngine and OCROptions in __init__.py for public API
- Add comprehensive unit tests:
  - test_parser_with_custom_ocr_options (single language)
  - test_parser_with_multilingual_tesseract (multiple languages)
  - test_parser_with_autodetect_tesseract (auto-detection)
  - Maintain backward compatibility with default EasyOCR
- Update documentation with detailed examples:
  - Basic OCR configuration
  - Single vs multiple languages
  - Automatic language detection
  - Common language codes reference
  - Backward compatibility with deprecated pdf_path parameter
- Maintain full backward compatibility (default: EasyOCR)