### PR TITLE
Create __init__ files in clients directories to fix pyright import errors in external projects.

### DIFF
--- a/datapizza-ai-clients/datapizza-ai-clients-anthropic/datapizza/clients/__init__.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-anthropic/datapizza/clients/__init__.py
@@ -1,0 +1,3 @@
+# This file makes datapizza.clients a namespace package
+# so that it can be correctly imported without pyright warnings
+# as a package when developing locally to test changes.

--- a/datapizza-ai-clients/datapizza-ai-clients-azure-openai/datapizza/clients/__init__.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-azure-openai/datapizza/clients/__init__.py
@@ -1,0 +1,3 @@
+# This file makes datapizza.clients a namespace package
+# so that it can be correctly imported without pyright warnings
+# as a package when developing locally to test changes.

--- a/datapizza-ai-clients/datapizza-ai-clients-bedrock/datapizza/clients/__init__.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-bedrock/datapizza/clients/__init__.py
@@ -1,0 +1,3 @@
+# This file makes datapizza.clients a namespace package
+# so that it can be correctly imported without pyright warnings
+# as a package when developing locally to test changes.

--- a/datapizza-ai-clients/datapizza-ai-clients-google/datapizza/clients/__init__.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-google/datapizza/clients/__init__.py
@@ -1,0 +1,3 @@
+# This file makes datapizza.clients a namespace package
+# so that it can be correctly imported without pyright warnings
+# as a package when developing locally to test changes.

--- a/datapizza-ai-clients/datapizza-ai-clients-mistral/datapizza/clients/__init__.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-mistral/datapizza/clients/__init__.py
@@ -1,0 +1,3 @@
+# This file makes datapizza.clients a namespace package
+# so that it can be correctly imported without pyright warnings
+# as a package when developing locally to test changes.

--- a/datapizza-ai-clients/datapizza-ai-clients-openai-like/datapizza/clients/__init__.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-openai-like/datapizza/clients/__init__.py
@@ -1,0 +1,3 @@
+# This file makes datapizza.clients a namespace package
+# so that it can be correctly imported without pyright warnings
+# as a package when developing locally to test changes.

--- a/datapizza-ai-clients/datapizza-ai-clients-openai/datapizza/clients/__init__.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-openai/datapizza/clients/__init__.py
@@ -1,0 +1,3 @@
+# This file makes datapizza.clients a namespace package
+# so that it can be correctly imported without pyright warnings
+# as a package when developing locally to test changes.


### PR DESCRIPTION
PR to address this [Issue](https://github.com/datapizza-labs/datapizza-ai/issues/88).