### PR TITLE
fix: initialized stop_reason to avoid UnboundLocalError

### DIFF
--- a/datapizza-ai-clients/datapizza-ai-clients-google/datapizza/clients/google/google_client.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-google/datapizza/clients/google/google_client.py
@@ -274,10 +274,10 @@ class GoogleClient(Client):
         )
 
         message_text = ""
+        stop_reason = ""
         thought_block = ThoughtBlock(content="")
 
         usage = TokenUsage()
-        stop_reason = ""
 
         for chunk in self.client.models.generate_content_stream(
             model=self.model_name,
@@ -358,6 +358,7 @@ class GoogleClient(Client):
 
         usage = TokenUsage()
         message_text = ""
+        stop_reason = ""
         thought_block = ThoughtBlock(content="")
         async for chunk in await self.client.aio.models.generate_content_stream(
             model=self.model_name,


### PR DESCRIPTION
## Description
While using the framework, I encountered a crash when calling the Gemini API.
If generate_content_stream produces no iterations, the loop is never entered and stop_reason is never initialized.
However, stop_reason is later referenced in the final ClientResponse, causing the program to raise an UnboundLocalError.

This PR initializes stop_reason before the loop to ensure it always has a valid value, even when the stream returns no chunks.