### PR TITLE
feat: add state graph pipeline

### DIFF
--- a/datapizza-ai-core/datapizza/pipeline/__init__.py
+++ b/datapizza-ai-core/datapizza/pipeline/__init__.py
@@ -1,5 +1,12 @@
 from .dag_pipeline import DagPipeline
 from .functional_pipeline import Dependency, FunctionalPipeline
 from .pipeline import IngestionPipeline
+from .state_graph import StateGraph
 
-__all__ = ["DagPipeline", "Dependency", "FunctionalPipeline", "IngestionPipeline"]
+__all__ = [
+    "DagPipeline",
+    "Dependency",
+    "FunctionalPipeline",
+    "IngestionPipeline",
+    "StateGraph",
+]

--- a/datapizza-ai-core/datapizza/pipeline/state_graph.py
+++ b/datapizza-ai-core/datapizza/pipeline/state_graph.py
@@ -1,0 +1,244 @@
+import logging
+import sys
+from collections.abc import Callable
+from dataclasses import Field, dataclass
+from typing import Any, ClassVar, Generic, Protocol, TypeAlias, TypeVar
+
+log = logging.getLogger(__name__)
+
+
+START = sys.intern("__start__")
+END = sys.intern("__end__")
+
+
+@dataclass
+class Node:
+    component: Callable[..., Any]
+    data: dict | None
+    src_keys: dict[str, str] | None
+    dst_key: str | None
+
+
+@dataclass
+class SimpleEdge:
+    to_node_name: str
+
+
+@dataclass
+class ConditionalEdge:
+    to_node_names: list[str]
+    component: Callable[..., str]
+
+
+class DataclassLike(Protocol):
+    """Protocol to represent types that behave like dataclasses.
+
+    Inspired by the private _DataclassT from dataclasses that uses a similar protocol as a bound."""
+
+    __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
+
+
+Edge: TypeAlias = SimpleEdge | ConditionalEdge
+
+StateT = TypeVar("StateT", bound=DataclassLike)
+
+
+class StateGraph(Generic[StateT]):
+    """
+    A pipeline that runs a graph of a dependency graph.
+    """
+
+    # TODO: from yaml
+    # TODO: to diagram
+    # TODO: validate src and dst keys
+
+    nodes: dict[str, Node]
+    edges: dict[str, Edge]
+
+    state_schema: type[StateT]
+
+    def __init__(self, state_schema: type[StateT]):
+        self.nodes = {}
+        self.edges = {}
+
+        self.state_schema = state_schema
+
+    def _validate_new_edge(self, source_node: str, target_nodes: list[str]):
+        """
+        Validates a new edge.
+
+        Args:
+            source_node (str): The source node.
+            target_nodes (list[str]): The target nodes.
+
+        Raises:
+            ValueError: If the edge is invalid.
+        """
+        if source_node not in self.nodes and source_node not in (START, END):
+            raise ValueError(f"Source node {source_node} does not exist in the graph.")
+
+        for target_node in target_nodes:
+            if target_node not in self.nodes and target_node not in (START, END):
+                raise ValueError(
+                    f"Target node {target_node} does not exist in the graph."
+                )
+
+        if source_node in self.edges:
+            raise ValueError(f"Source node {source_node} already has an outgoing edge.")
+
+    def _validate_graph(self):
+        """
+        Validates the graph.
+
+        The following conditions must be met:
+        - START and END nodes must be connected
+
+        Raises:
+            ValueError: If the graph is invalid.
+        """
+        if START not in self.edges:
+            raise ValueError("Graph must have a START node connected.")
+
+        connected_edges = set()
+        for edge in self.edges.values():
+            if isinstance(edge, SimpleEdge):
+                connected_edges.add(edge.to_node_name)
+            elif isinstance(edge, ConditionalEdge):
+                connected_edges.update(edge.to_node_names)
+            else:
+                raise ValueError("Unknown edge type.")
+
+        if END not in connected_edges:
+            raise ValueError("Graph must have an END node connected.")
+
+    def add_module(
+        self,
+        node_name: str,
+        node: Callable[..., Any],
+        data: dict | None = None,
+        src_keys: dict[str, str] | None = None,
+        dst_key: str | None = None,
+    ):
+        """
+        Add a module to the pipeline.
+
+        Args:
+            node_name (str): The name of the module.
+            node (Callable[..., Any]): The module to add.
+            data (dict | None): Fixed arguments for the module.
+            src_keys (dict[str, str] | None): Mapping of state keys to module input parameter names.
+            dst_key (str | None): The destination key for the module output.
+
+        Raises:
+            ValueError: If the node already exists.
+        """
+        if node_name in self.nodes:
+            raise ValueError(f"Node {node_name} already exists in the graph.")
+
+        self.nodes[node_name] = Node(
+            component=node,
+            data=data,
+            src_keys=src_keys,
+            dst_key=dst_key,
+        )
+
+    def connect(
+        self,
+        source_node: str,
+        target_node: str,
+    ):
+        """
+        Connect two nodes in the pipeline.
+
+        Args:
+            source_node (str): The name of the source node.
+            target_node (str): The name of the target node.
+        """
+        self._validate_new_edge(source_node, [target_node])
+
+        self.edges[source_node] = SimpleEdge(
+            to_node_name=target_node,
+        )
+
+    def branch(
+        self,
+        node_name: str,
+        node: Callable[..., str],
+        path_map: list[str],
+    ):
+        self._validate_new_edge(node_name, path_map)
+
+        self.edges[node_name] = ConditionalEdge(
+            to_node_names=path_map,
+            component=node,
+        )
+
+    def run(self, initial_state: StateT | None = None) -> StateT:
+        """
+        Run the pipeline.
+
+        Args:
+            initial_state (StateT | None): The initial state of the pipeline. If None, an empty state will be used.
+
+        Returns:
+            StateT: The state of the pipeline.
+        """
+        self._validate_graph()
+
+        state = self.state_schema() if initial_state is None else initial_state
+
+        current_edge = self.edges[START]
+
+        while True:
+            # Evaluate the current edge to get the next node
+            node_name = None
+            if isinstance(current_edge, SimpleEdge):
+                node_name = current_edge.to_node_name
+            elif isinstance(current_edge, ConditionalEdge):
+                node_name = current_edge.component(state)
+                if node_name not in current_edge.to_node_names:
+                    raise ValueError(
+                        f"Branch node returned invalid path '{node_name}', expected one of {current_edge.to_node_names}."
+                    )
+            else:
+                raise ValueError("Unknown edge type.")
+
+            # Check for end node
+            if node_name == END:
+                break
+
+            # Execute the node
+            node = self.nodes[node_name]
+            try:
+                log.debug(f"State before node {node_name}: {state}")
+
+                arguments = node.data or {}
+                if node.src_keys:
+                    for param_name, state_key in node.src_keys.items():
+                        arguments[param_name] = getattr(state, state_key)
+                else:
+                    arguments.update(state.__dict__)
+
+                node_output = node.component(**arguments)
+                if node.dst_key:
+                    setattr(state, node.dst_key, node_output)
+                elif isinstance(node_output, dict):
+                    state = self.state_schema(**node_output)
+                else:
+                    raise ValueError(
+                        f"Node {node_name} did not return a dict and no dst_key was specified."
+                    )
+
+                # Get the next edge
+                current_edge = self.edges[node_name]
+
+            except Exception as e:
+                log.error(f"Error running node {node_name}: {e!s}")
+                raise
+
+        return state
+
+    async def a_run(self, initial_state: StateT | None = None) -> StateT:
+        # TODO: add async support
+
+        return self.run(initial_state)


### PR DESCRIPTION
# Description

With this PR, I want to add support for state graphs, based on the LangGraph idea but with a syntax that supports the modules already present in Datapizza.

The development is not complete, but the PR should also serve to discuss the syntax used, to ensure that it reflects the maintainers' idea.

# Example

This example is based on the `DagPipeline` example in the documentation

<details>
<summary>Example implementation code</summary>

```python
from dataclasses import dataclass
from typing import Any

from datapizza.clients.google import GoogleClient
from datapizza.core.vectorstore import VectorConfig
from datapizza.embedders.google import GoogleEmbedder
from datapizza.modules.prompt import ChatPromptTemplate
from datapizza.modules.rewriters import ToolRewriter
from datapizza.pipeline.state_graph import END, START, StateGraph
from datapizza.vectorstores.qdrant import QdrantVectorstore

client = GoogleClient(api_key="...", model="gemini-2.5-flash-lite")
embedder = GoogleEmbedder(api_key="...", model_name="gemini-embedding-001")
vector_store = QdrantVectorstore(location=":memory:")
vector_store.create_collection(collection_name="my_documents",vector_config=[VectorConfig(dimensions=3072, name="vector_name")],)

@dataclass
class StateSchema:
    user_prompt: str
    system_prompt: str

    iteration: int = 1

    rewriter: Any | None = None
    embedder: Any | None = None
    vector_store: list | None = None
    prompt_template: Any | None = None
    llm: Any | None = None

pipeline = StateGraph(StateSchema)

pipeline.add_module(
    "rewriter",
    ToolRewriter(
        client=client,
        system_prompt="rewrite the query to perform a better search in a vector database",
    ),
    src_keys={"user_prompt": "user_prompt"},
    dst_key="rewriter",
)
pipeline.add_module(
    "embedder",
    embedder,
    src_keys={"text": "rewriter"},
    dst_key="embedder",
)
pipeline.add_module(
    "vector_store",
    vector_store.as_module_component(),
    data={"collection_name": "my_documents","k": 10},
    src_keys={"query_vector": "embedder"},
    dst_key="vector_store",
)
pipeline.add_module(
    "prompt_template",
    ChatPromptTemplate(
        user_prompt_template="this is a user prompt: {{ user_prompt }}",
        retrieval_prompt_template="{% for chunk in chunks %} Relevant chunk: {{ chunk.text }} \n\n {% endfor %}",
    ),
    src_keys={"chunks": "vector_store", "user_prompt": "user_prompt"},
    dst_key="prompt_template",
)
pipeline.add_module(
    "llm",
    client.as_module_component(),
    src_keys={"memory": "prompt_template","input": "user_prompt","system_prompt": "system_prompt"},
    dst_key="llm",
)

def quick_exit(state: StateSchema) -> str:
    if state.vector_store is None or len(state.vector_store) == 0:
        if state.iteration > 1:
            print("No relevant documents found after multiple iterations, exiting.")
            return END
        else:
            state.iteration += 1
            print("No relevant documents found, switching to the backup question.")
            state.user_prompt = "How did Ultron gain sentience?"
            return "rewriter"
    return "prompt_template"

pipeline.connect(START, "rewriter")
pipeline.connect("rewriter", "embedder")
pipeline.connect("embedder", "vector_store")
pipeline.branch("vector_store", quick_exit, [END, "prompt_template", "rewriter"])
pipeline.connect("prompt_template", "llm")
pipeline.connect("llm", END)

state = pipeline.run(
    StateSchema(
        user_prompt="tell me something about this document",
        system_prompt="You are a helpful assistant.",
    )
)
print("Result:", state.llm)
```
</details>

# Syntax

In a state graph, the state should be global and each module should be able to read it in its entirety and update it. However, the modules in Datapizza require specific fields and return only one value. For this reason, when defining the module, I decided to add the `src_keys` field, which allows you to specify which state keys to add to the call arguments and under which name. In addition, the `dst_key` field allows you to specify in which state field to insert the output.

However, if the module is compatible with the state, i.e., it is able to read the entire state and return an updated one, these fields can be omitted.

Furthermore, in this implementation, I moved the definition of the “data” field from the pipeline's `run` method to a specific field in the module creation. The `run` method now accepts the initial state.

Regarding the state, `dataclasses` are supported, so you have control over the names of the keys.

Branches are treated as special edges that execute a function that returns a string to identify the next module. These functions can be any type of callable, even a `PipelineComponent`.

# Doubts

- For modules that can read the entire state and return an updated one, is it better for the state to be passed as `.run(state)` or `.run(**state)`?

# TODOs

- [ ] Add the function to create from yaml
- [ ] Add the function to generate the grap's mermaid chart
- [ ] Validate src_keys and dst_key
- [ ] Support async
