### PR TITLE
refactor(fastembedder): simplify embed methods and fix async handling

### DIFF
--- a/datapizza-ai-embedders/fastembedder/datapizza/embedders/fastembedder/fastembedder.py
+++ b/datapizza-ai-embedders/fastembedder/datapizza/embedders/fastembedder/fastembedder.py
@@ -27,7 +27,7 @@ class FastEmbedder(BaseEmbedder):
         )
 
     def embed(
-        self, text: str | list[str], model_name: str | None = None
+        self, text: str | list[str]
     ) -> SparseEmbedding | list[SparseEmbedding]:
         # fastembed accepts both str and list[str]. Passing the list allows for batch processing.
         embeddings = self.embedder.embed(text)
@@ -45,6 +45,6 @@ class FastEmbedder(BaseEmbedder):
         return results[0]
 
     async def a_embed(
-        self, text: str | list[str], model_name: str | None = None
+        self, text: str | list[str]
     ) -> SparseEmbedding | list[SparseEmbedding]:
-        return await asyncio.to_thread(self.embed, text, model_name)
+        return await asyncio.to_thread(self.embed, text)


### PR DESCRIPTION
This PR refactors async embed
- Leverage fastembed's native batch processing instead of manual iteration
- Remove duplicated embedding logic between `embed()` and `a_embed()`
- Use `asyncio.to_thread()` to properly offload blocking I/O in `a_embed()`

## Changes

- **Simplified `embed()`**: Now passes lists directly to fastembed for batch processing instead of iterating one-by-one
- **DRY `a_embed()`**: Delegates to `embed()` via `asyncio.to_thread()` instead of duplicating all logic
- Reduces ~25 lines of duplicated code

## Notes

**Previous behavior issue**: The old `a_embed()` was marked as `async` but was entirely synchronous, it blocked the event loop while embedding. The new implementation correctly offloads the blocking work to a thread pool.
This could also use tests