### PR TITLE
feat: allow "url" source_type for pdf in google memory adapter

### DIFF
--- a/datapizza-ai-clients/datapizza-ai-clients-google/datapizza/clients/google/memory_adapter.py
+++ b/datapizza-ai-clients/datapizza-ai-clients-google/datapizza/clients/google/memory_adapter.py
@@ -102,6 +102,11 @@ class GoogleMemoryAdapter(MemoryAdapter):
                         "data": pdf_bytes,
                     }
                 }
+            case "url":
+                return types.Part.from_uri(
+                    file_uri=block.media.source,
+                    mime_type="application/pdf",
+                )
 
             case _:
                 raise NotImplementedError(


### PR DESCRIPTION
This pull request adds support for handling PDF blocks with a "url" source in the `_process_pdf_block` method. Now, when a PDF block's source type is "url", it will be processed using the `types.Part.from_uri` method, enabling the system to handle remote PDF files.

Enhancement to PDF block processing:

* Added handling for PDF blocks with a "url" source by returning a `types.Part` object created from the URI, allowing support for remote PDF files.